### PR TITLE
Fix PyTorch spelling

### DIFF
--- a/Pages/About/About.html
+++ b/Pages/About/About.html
@@ -63,7 +63,7 @@
         <div class="skills-container">
           <div class="skill-block">
             <h3>Programming</h3>
-            <p>Python (Scikit-learn, Pytorch, TensorFlow), MATLAB, JavaScript, Node.js, Java, C, C++</p>
+            <p>Python (Scikit-learn, PyTorch, TensorFlow), MATLAB, JavaScript, Node.js, Java, C, C++</p>
           </div>
           <div class="skill-block">
             <h3>Neuroimaging</h3>


### PR DESCRIPTION
## Summary
- correct PyTorch capitalization in About page

## Testing
- `npm test` *(fails: no `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_684160ad4bfc832f80cfcb9ce3740118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Corrected the capitalization of "PyTorch" in the Programming skills list on the About page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->